### PR TITLE
Fix silence detection

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -86,6 +86,8 @@ fn start(
                     }
                 }
             }
+        } else {
+            silence_start = None;
         }
     }
 }


### PR DESCRIPTION
When silence is not detected we need to reset the silence start timer